### PR TITLE
Fix Transaction Persistence Problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,5 @@ ENV CL_SOURCE_REGISTRY=/app
 RUN mkdir /app
 WORKDIR /app
 
+RUN mkdir /volumes
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,3 @@ ENV CL_SOURCE_REGISTRY=/app
 RUN mkdir /app
 WORKDIR /app
 
-RUN mkdir /volumes
-

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,6 @@ setup:
 
 test.prev:
 	docker-compose down || true
-	rm -rf ./volumes
-	mkdir ./volumes
-	mkdir ./volumes/mysql
-	mkdir ./volumes/postgresql
-	mkdir ./volumes/postgresql/data
-	mkdir ./volumes/postgresql/log
-	sleep 1
 	docker-compose up -d
 	echo wait...
 	sleep 10

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: setup test.prev test test.down test.console test.swank
 setup:
-	docker build -t dbi-cp-test .
+	docker build -t dbi-cp-test . --no-cache
 
 test.prev:
 	docker-compose down || true

--- a/dbi-cp-test.asd
+++ b/dbi-cp-test.asd
@@ -20,6 +20,11 @@
                   :components
                   ((:file "sqlite3")
                    (:file "mysql")
+                   (:file "postgres")))
+                 (:module "transaction"
+                  :components
+                  ((:file "sqlite3")
+                   (:file "mysql")
                    (:file "postgres"))))))
   :description "Test system for CL-DBI-CONNECTION-POOL"
 

--- a/docker-compose.test-runner.yml
+++ b/docker-compose.test-runner.yml
@@ -7,3 +7,5 @@ services:
     container_name: dbi_cp_test
     volumes:
       - ./:/app
+    tmpfs:
+      - /volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: test
-    volumes:
-      - ./volumes/mysql:/var/lib/mysql
+    tmpfs:
+      - /var/lib/mysql
   postgresql-test:
     image: postgres:16
     container_name: dbi-cp_test_postgresql
@@ -15,6 +15,6 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: test
       PGDATA: /var/lib/postgresql/data/pgdata
-    volumes:
-      - ./volumes/postgresql/data:/var/lib/postgresql/data
-      - ./volumes/postgresql/log:/var/log
+    tmpfs:
+      - /var/lib/postgresql/data
+      - /var/log

--- a/src/connectionpool.lisp
+++ b/src/connectionpool.lisp
@@ -82,7 +82,11 @@ Example
     ;; connected
     (setf (connect-p pooled-connection) T)
     ;; make connection
-    (setf (dbi-connection dbi-proxy) (funcall connect-fn))
+    (let ((dbi-connection (funcall connect-fn)))
+      (setf (dbi-connection dbi-proxy) dbi-connection)
+      ;; Save initial auto-commit value
+      (setf (slot-value dbi-proxy 'dbi-cp.proxy::initial-auto-commit)
+            (slot-value dbi-connection 'dbi.driver::auto-commit)))
     ;; make disconnect callback
     (setf (disconnect-fn dbi-proxy)
           (lambda ()

--- a/t/proxy/sqlite3.lisp
+++ b/t/proxy/sqlite3.lisp
@@ -9,7 +9,7 @@
 
 (setup
   (setf *connection-pool* (make-dbi-connection-pool :sqlite3
-                                                    :database-name "/app/volumes/sqlite3-test.db"
+                                                    :database-name "/volumes/sqlite3-test.db"
                                                     :initial-size 2
                                                     :max-size 3)))
 

--- a/t/transaction/mysql.lisp
+++ b/t/transaction/mysql.lisp
@@ -1,0 +1,182 @@
+(in-package :cl-user)
+(defpackage dbi-cp-transaction-mysql-test
+  (:use :cl
+        :dbi-cp
+        :rove))
+(in-package :dbi-cp-transaction-mysql-test)
+
+(defvar *connection-pool* nil)
+
+(setup
+  (setf *connection-pool* (make-dbi-connection-pool :mysql
+                                                    :database-name "test"
+                                                    :username "root"
+                                                    :password "password"
+                                                    :host "mysql-test"
+                                                    :port 3306
+                                                    :initial-size 2
+                                                    :max-size 3)))
+
+(teardown
+  (shutdown *connection-pool*))
+
+
+(deftest mysql-issue11-pattern8-begin-transaction-disconnect
+  (testing "Pattern 8: begin-transaction → disconnect"
+    ;; First user: begin-transaction but no commit/rollback
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 1"))
+             (result (execute query)))
+        ;; Alice should not exist (rolled back)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest mysql-issue11-pattern9-begin-transaction-insert-disconnect
+  (testing "Pattern 9: begin-transaction + INSERT → disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT but no commit
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (2, 'Bob')")
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 2"))
+             (result (execute query)))
+        ;; Bob should not exist (rolled back)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest mysql-issue11-pattern10-begin-transaction-commit-disconnect
+  (testing "Pattern 10: begin-transaction + commit → disconnect (commit does not work)"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + commit (but commit does nothing)
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (3, 'Charlie')")
+      (commit conn)  ;; This does nothing because *transaction-state* is nil
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 3"))
+             (result (execute query)))
+        ;; Charlie should not exist (rolled back on disconnect)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest mysql-issue11-pattern11-begin-transaction-rollback-disconnect
+  (testing "Pattern 11: begin-transaction + rollback → disconnect (rollback does not work)"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + rollback (but rollback does nothing)
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (4, 'Dave')")
+      (rollback conn)  ;; This does nothing because *transaction-state* is nil
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 4"))
+             (result (execute query)))
+        ;; Dave should not exist (rolled back on disconnect)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest mysql-issue11-pattern12-begin-transaction-with-transaction-disconnect
+  (testing "Pattern 12: begin-transaction + with-transaction → disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users2")
+      (do-sql conn "CREATE TABLE users2 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + with-transaction
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (with-transaction conn
+        (do-sql conn "INSERT INTO users2 (id, name) VALUES (5, 'Eve')"))
+      (disconnect conn))
+    
+    ;; Next user: Should see committed data
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users2 WHERE id = 5"))
+             (result (execute query)))
+        ;; Eve should exist (committed by with-transaction)
+        (ok (equal (fetch result) '(:|id| 5 :|name| "Eve"))))
+      (disconnect conn))))
+
+
+(deftest mysql-issue11-pattern13-begin-transaction-insert-with-transaction-disconnect
+  (testing "Pattern 13: begin-transaction + INSERT + with-transaction → disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users3")
+      (do-sql conn "CREATE TABLE users3 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + with-transaction
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users3 (id, name) VALUES (6, 'Frank')")
+      (with-transaction conn
+        (do-sql conn "INSERT INTO users3 (id, name) VALUES (7, 'Grace')"))
+      (disconnect conn))
+    
+    ;; Next user: Both should exist (committed by with-transaction)
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query1 (prepare conn "SELECT * FROM users3 WHERE id = 6"))
+             (result1 (execute query1))
+             (query2 (prepare conn "SELECT * FROM users3 WHERE id = 7"))
+             (result2 (execute query2)))
+        ;; Frank should exist
+        (ok (equal (fetch result1) '(:|id| 6 :|name| "Frank")))
+        ;; Grace should exist
+        (ok (equal (fetch result2) '(:|id| 7 :|name| "Grace"))))
+      (disconnect conn))))
+
+
+(deftest mysql-issue11-auto-commit-restoration
+  (testing "auto-commit flag should be restored after disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users4")
+      (do-sql conn "CREATE TABLE users4 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction changes auto-commit to nil
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      ;; auto-commit is now nil
+      (disconnect conn))
+    
+    ;; Next user: auto-commit should be restored to initial value
+    (let ((conn (get-connection *connection-pool*)))
+      (let ((dbi-conn (slot-value conn 'dbi-cp.proxy::dbi-connection))
+            (initial-auto-commit (slot-value conn 'dbi-cp.proxy::initial-auto-commit)))
+        ;; auto-commit should match initial-auto-commit
+        (ok (eq (slot-value dbi-conn 'dbi.driver::auto-commit)
+                initial-auto-commit)))
+      (disconnect conn))))

--- a/t/transaction/postgres.lisp
+++ b/t/transaction/postgres.lisp
@@ -1,0 +1,182 @@
+(in-package :cl-user)
+(defpackage dbi-cp-transaction-postgres-test
+  (:use :cl
+        :dbi-cp
+        :rove))
+(in-package :dbi-cp-transaction-postgres-test)
+
+(defvar *connection-pool* nil)
+
+(setup
+  (setf *connection-pool* (make-dbi-connection-pool :postgres
+                                                    :database-name "test"
+                                                    :username "dbicp"
+                                                    :password "password"
+                                                    :host "postgresql-test"
+                                                    :port 5432
+                                                    :initial-size 2
+                                                    :max-size 3)))
+
+(teardown
+  (shutdown *connection-pool*))
+
+
+(deftest postgres-issue11-pattern8-begin-transaction-disconnect
+  (testing "Pattern 8: begin-transaction → disconnect"
+    ;; First user: begin-transaction but no commit/rollback
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 1"))
+             (result (execute query)))
+        ;; Alice should not exist (rolled back)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest postgres-issue11-pattern9-begin-transaction-insert-disconnect
+  (testing "Pattern 9: begin-transaction + INSERT → disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT but no commit
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (2, 'Bob')")
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 2"))
+             (result (execute query)))
+        ;; Bob should not exist (rolled back)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest postgres-issue11-pattern10-begin-transaction-commit-disconnect
+  (testing "Pattern 10: begin-transaction + commit → disconnect (commit does not work)"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + commit (but commit does nothing)
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (3, 'Charlie')")
+      (commit conn)  ;; This does nothing because *transaction-state* is nil
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 3"))
+             (result (execute query)))
+        ;; Charlie should not exist (rolled back on disconnect)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest postgres-issue11-pattern11-begin-transaction-rollback-disconnect
+  (testing "Pattern 11: begin-transaction + rollback → disconnect (rollback does not work)"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + rollback (but rollback does nothing)
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (4, 'Dave')")
+      (rollback conn)  ;; This does nothing because *transaction-state* is nil
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 4"))
+             (result (execute query)))
+        ;; Dave should not exist (rolled back on disconnect)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest postgres-issue11-pattern12-begin-transaction-with-transaction-disconnect
+  (testing "Pattern 12: begin-transaction + with-transaction → disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users2")
+      (do-sql conn "CREATE TABLE users2 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + with-transaction
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (with-transaction conn
+        (do-sql conn "INSERT INTO users2 (id, name) VALUES (5, 'Eve')"))
+      (disconnect conn))
+    
+    ;; Next user: Should see committed data
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users2 WHERE id = 5"))
+             (result (execute query)))
+        ;; Eve should exist (committed by with-transaction)
+        (ok (equal (fetch result) '(:|id| 5 :|name| "Eve"))))
+      (disconnect conn))))
+
+
+(deftest postgres-issue11-pattern13-begin-transaction-insert-with-transaction-disconnect
+  (testing "Pattern 13: begin-transaction + INSERT + with-transaction → disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users3")
+      (do-sql conn "CREATE TABLE users3 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + with-transaction
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users3 (id, name) VALUES (6, 'Frank')")
+      (with-transaction conn
+        (do-sql conn "INSERT INTO users3 (id, name) VALUES (7, 'Grace')"))
+      (disconnect conn))
+    
+    ;; Next user: Both should exist (committed by with-transaction)
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query1 (prepare conn "SELECT * FROM users3 WHERE id = 6"))
+             (result1 (execute query1))
+             (query2 (prepare conn "SELECT * FROM users3 WHERE id = 7"))
+             (result2 (execute query2)))
+        ;; Frank should exist
+        (ok (equal (fetch result1) '(:|id| 6 :|name| "Frank")))
+        ;; Grace should exist
+        (ok (equal (fetch result2) '(:|id| 7 :|name| "Grace"))))
+      (disconnect conn))))
+
+
+(deftest postgres-issue11-auto-commit-restoration
+  (testing "auto-commit flag should be restored after disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users4")
+      (do-sql conn "CREATE TABLE users4 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction changes auto-commit to nil
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      ;; auto-commit is now nil
+      (disconnect conn))
+    
+    ;; Next user: auto-commit should be restored to initial value
+    (let ((conn (get-connection *connection-pool*)))
+      (let ((dbi-conn (slot-value conn 'dbi-cp.proxy::dbi-connection))
+            (initial-auto-commit (slot-value conn 'dbi-cp.proxy::initial-auto-commit)))
+        ;; auto-commit should match initial-auto-commit
+        (ok (eq (slot-value dbi-conn 'dbi.driver::auto-commit)
+                initial-auto-commit)))
+      (disconnect conn))))

--- a/t/transaction/sqlite3.lisp
+++ b/t/transaction/sqlite3.lisp
@@ -1,0 +1,176 @@
+(in-package :cl-user)
+(defpackage dbi-cp-transaction-sqlite3-test
+  (:use :cl
+        :dbi-cp
+        :rove))
+(in-package :dbi-cp-transaction-sqlite3-test)
+
+(defvar *connection-pool* nil)
+
+(setup
+  (setf *connection-pool* (make-dbi-connection-pool :sqlite3
+                                                    :database-name "/volumes/sqlite3-test-transaction.db"
+                                                    :initial-size 2
+                                                    :max-size 3)))
+
+(teardown
+  (shutdown *connection-pool*))
+
+
+(deftest sqlite3-issue11-pattern8-begin-transaction-disconnect
+  (testing "Pattern 8: begin-transaction → disconnect"
+    ;; First user: begin-transaction but no commit/rollback
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 1"))
+             (result (execute query)))
+        ;; Alice should not exist (rolled back)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest sqlite3-issue11-pattern9-begin-transaction-insert-disconnect
+  (testing "Pattern 9: begin-transaction + INSERT → disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT but no commit
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (2, 'Bob')")
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 2"))
+             (result (execute query)))
+        ;; Bob should not exist (rolled back)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest sqlite3-issue11-pattern10-begin-transaction-commit-disconnect
+  (testing "Pattern 10: begin-transaction + commit → disconnect (commit does not work)"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + commit (but commit does nothing)
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (3, 'Charlie')")
+      (commit conn)  ;; This does nothing because *transaction-state* is nil
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 3"))
+             (result (execute query)))
+        ;; Charlie should not exist (rolled back on disconnect)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest sqlite3-issue11-pattern11-begin-transaction-rollback-disconnect
+  (testing "Pattern 11: begin-transaction + rollback → disconnect (rollback does not work)"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users")
+      (do-sql conn "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction + INSERT + rollback (but rollback does nothing)
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      (do-sql conn "INSERT INTO users (id, name) VALUES (4, 'Dave')")
+      (rollback conn)  ;; This does nothing because *transaction-state* is nil
+      (disconnect conn))
+    
+    ;; Next user: Should get clean connection
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((query (prepare conn "SELECT * FROM users WHERE id = 4"))
+             (result (execute query)))
+        ;; Dave should not exist (rolled back on disconnect)
+        (ok (null (fetch result))))
+      (disconnect conn))))
+
+
+(deftest sqlite3-issue11-pattern12-begin-transaction-with-transaction-disconnect
+  (testing "Pattern 12: begin-transaction + with-transaction → disconnect"
+    ;; Setup table
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users2")
+      (do-sql conn "CREATE TABLE users2 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; SQLite3 raises "cannot start a transaction within a transaction" error
+    ;; when with-transaction is called after begin-transaction.
+    ;; This is expected behavior for SQLite3.
+    ;; We verify that the error is properly raised and handled.
+    (handler-case
+        (let ((conn (get-connection *connection-pool*)))
+          (unwind-protect
+            (progn
+              (begin-transaction conn)
+              (with-transaction conn
+                (do-sql conn "INSERT INTO users2 (id, name) VALUES (5, 'Eve')")))
+            (disconnect conn)))
+      (error (e)
+        (ok t "Error was raised as expected for SQLite3")))))
+
+
+(deftest sqlite3-issue11-pattern13-begin-transaction-insert-with-transaction-disconnect
+  (testing "Pattern 13: begin-transaction + INSERT + with-transaction → disconnect"
+    ;; Setup table
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users3")
+      (do-sql conn "CREATE TABLE users3 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; SQLite3 raises "cannot start a transaction within a transaction" error
+    ;; when with-transaction is called after begin-transaction.
+    ;; This is expected behavior for SQLite3.
+    ;; We verify that the error is properly raised and handled.
+    (handler-case
+        (let ((conn (get-connection *connection-pool*)))
+          (unwind-protect 
+            (progn
+              (begin-transaction conn)
+              (do-sql conn "INSERT INTO users3 (id, name) VALUES (6, 'Frank')")
+              (with-transaction conn
+                (do-sql conn "INSERT INTO users3 (id, name) VALUES (7, 'Grace')")))
+          (disconnect conn)))
+      (error (e)
+        (ok t "Error was raised as expected for SQLite3")))))
+
+
+(deftest sqlite3-issue11-auto-commit-restoration
+  (testing "auto-commit flag should be restored after disconnect"
+    (let ((conn (get-connection *connection-pool*)))
+      (do-sql conn "DROP TABLE IF EXISTS users4")
+      (do-sql conn "CREATE TABLE users4 (id INTEGER PRIMARY KEY, name VARCHAR(255))")
+      (disconnect conn))
+    
+    ;; First user: begin-transaction changes auto-commit to nil
+    (let ((conn (get-connection *connection-pool*)))
+      (begin-transaction conn)
+      ;; auto-commit is now nil
+      (disconnect conn))
+    
+    ;; Next user: auto-commit should be restored to initial value
+    (let ((conn (get-connection *connection-pool*)))
+      (let ((dbi-conn (slot-value conn 'dbi-cp.proxy::dbi-connection))
+            (initial-auto-commit (slot-value conn 'dbi-cp.proxy::initial-auto-commit)))
+        ;; auto-commit should match initial-auto-commit
+        (ok (eq (slot-value dbi-conn 'dbi.driver::auto-commit)
+                initial-auto-commit)))
+      (disconnect conn))))


### PR DESCRIPTION
close: #11 

## Overview

Fixed the issue where uncommitted transactions started with `begin-transaction` are inherited by the next user when a connection is returned to the pool without completing the transac
tion.

## Main Changes

### 1. Transaction State Tracking

- Added `begin-transaction-called` flag to track whether `begin-transaction` was called
- Clear the flag when `with-transaction` completes (since commit/rollback is executed within `with-transaction`)

### 2. Processing on Disconnect

- Automatically rollback uncommitted transactions if `begin-transaction-called` flag is set
- Added error handling to ignore errors when already outside a transaction

### 3. Auto-commit Flag Restoration

- Save the initial value of `auto-commit` flag when creating a connection
- Restore the `auto-commit` flag to its initial value when returning a connection
- Prevent `auto-commit=false` state from `begin-transaction` being inherited by the next user

### 4. Warning Addition

- Display a warning when `begin-transaction` is used
- Added message recommending the use of `with-transaction`

### 5. Test Addition                                                                                                                                                          [16/1973]

Added tests for patterns 8-13 and auto-commit restoration across 3 databases:

- `t/transaction/sqlite3.lisp` - SQLite3 tests (7 tests)
- `t/transaction/mysql.lisp` - MySQL tests (7 tests)
- `t/transaction/postgres.lisp` - PostgreSQL tests (7 tests)

Test patterns for each database:
- pattern8: `begin-transaction` → `disconnect`
- pattern9: `begin-transaction` + `INSERT` → `disconnect`
- pattern10: `begin-transaction` + `commit` → `disconnect`
- pattern11: `begin-transaction` + `rollback` → `disconnect`
- pattern12: `begin-transaction` + `with-transaction` → `disconnect`
- pattern13: `begin-transaction` + `INSERT` + `with-transaction` → `disconnect`
- auto-commit-restoration: Verify auto-commit flag restoration

## Technical Details

### Difference Between begin-transaction and with-transaction

Due to cl-dbi's design:

- Only when using `with-transaction`, `*transaction-state*` is set and commit/rollback functions
- When using only `begin-transaction`, calling `commit`/`rollback` does nothing

Therefore, in the connection pool:

- Record that `begin-transaction` was called with a flag
- When `with-transaction` is called, clear the flag since commit/rollback is executed within it
- On `disconnect`, if the flag is set, issue `ROLLBACK` as an uncommitted transaction

### Database-Specific Behavior

**SQLite3**:
- Calling `with-transaction` after `begin-transaction` raises "cannot start a transaction within a transaction" error
- This is normal behavior according to SQLite3 specification
- Tests use `unwind-protect` to ensure connection return even when errors occur

**MySQL/PostgreSQL**:
- Only warning when calling `with-transaction` after `begin-transaction`
- Transactions can commit/rollback normally

## Impact

### Compatibility

- **No breaking changes**: Existing code using `with-transaction` continues to work as is
- Code using `begin-transaction` will show a warning but behavior is unchanged (however, it becomes safer as uncommitted transactions are automatically rolled back)

### Performance

- Minimal overhead when returning connections (only flag check and ROLLBACK issuance)
- No impact when using normal `with-transaction`


## Test Results

All 21 tests (3 databases × 7 tests) passed:

```
✓ 7 tests completed (SQLite3)
✓ 7 tests completed (MySQL)
✓ 7 tests completed (PostgreSQL)

Summary:
  All tests passed.
```

## Recommendations

- For new code, it is recommended to use `with-transaction` instead of `begin-transaction`
- `with-transaction` automatically performs commit/rollback and includes error handling, making it safer
