### PR TITLE
Add MySQL max_allowed_packet support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ setup:
 test.prev:
 	docker-compose down || true
 	docker-compose up -d
-	echo wait...
-	sleep 10
 
 test: test.prev
 	@echo "Running tests..."

--- a/dbi-cp-test.asd
+++ b/dbi-cp-test.asd
@@ -20,6 +20,7 @@
                   :components
                   ((:file "sqlite3")
                    (:file "mysql")
+                   (:file "mysql-max-allowed-packet")
                    (:file "postgres")))
                  (:module "transaction"
                   :components

--- a/dbi-cp.asd
+++ b/dbi-cp.asd
@@ -21,7 +21,8 @@
   :depends-on (:cl-syntax
                :cl-syntax-annot
                :cl-dbi
-               :bt-semaphore)
+               :bt-semaphore
+               :babel)
   :components ((:module "src"
                 :components
                 ((:file "dbi-cp" :depends-on ("connectionpool"))

--- a/docker-compose.test-runner.yml
+++ b/docker-compose.test-runner.yml
@@ -9,3 +9,18 @@ services:
       - ./:/app
     tmpfs:
       - /volumes
+    depends_on:
+      mysql-test:
+        condition: service_healthy
+      postgresql-test:
+        condition: service_healthy
+
+  mysql-test:
+    extends:
+      file: docker-compose.yml
+      service: mysql-test
+
+  postgresql-test:
+    extends:
+      file: docker-compose.yml
+      service: postgresql-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,15 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: test
+    command: --max_allowed_packet=1048576
     tmpfs:
       - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-ppassword"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
   postgresql-test:
     image: postgres:16
     container_name: dbi-cp_test_postgresql
@@ -18,3 +25,9 @@ services:
     tmpfs:
       - /var/lib/postgresql/data
       - /var/log
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dbicp"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s

--- a/src/dbi-cp.lisp
+++ b/src/dbi-cp.lisp
@@ -14,9 +14,13 @@
                 :begin-transaction
                 :commit
                 :rollback
-                :with-transaction)
+                :with-transaction
+                :get-max-allowed-packet
+                :check-packet-size
+                :packet-size-exceeded-p)
   (:import-from :dbi-cp.error
-                :<dbi-cp-no-connection>)
+                :<dbi-cp-no-connection>
+                :<dbi-cp-packet-size-exceeded>)
   (:import-from :dbi
                 :execute
                 :fetch
@@ -54,8 +58,12 @@
            :with-transaction
            :disconnect
            :shutdown
+           :get-max-allowed-packet
+           :check-packet-size
+           :packet-size-exceeded-p
 
            :<dbi-cp-no-connection>
+           :<dbi-cp-packet-size-exceeded>
 
            :<dbi-error>
            :<dbi-warning>

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -12,3 +12,21 @@
    (lambda (condition stream)
      (format stream
              "no database connection found"))))
+
+@export
+(define-condition <dbi-cp-packet-size-exceeded> (simple-error)
+  ((query-size :initarg :query-size
+               :reader query-size)
+   (max-allowed :initarg :max-allowed
+                :reader max-allowed)
+   (query :initarg :query
+          :reader query
+          :initform nil))
+  (:documentation "Exception raised when query size exceeds max_allowed_packet")
+  (:report
+   (lambda (condition stream)
+     (format stream
+             "Query size (~A bytes) exceeds max_allowed_packet (~A bytes)~@[~%Query: ~A~]"
+             (query-size condition)
+             (max-allowed condition)
+             (query condition)))))

--- a/t/proxy/mysql-max-allowed-packet.lisp
+++ b/t/proxy/mysql-max-allowed-packet.lisp
@@ -1,0 +1,159 @@
+(in-package :cl-user)
+(defpackage dbi-cp-mysql-max-allowed-packet-test
+  (:use :cl
+        :dbi-cp
+        :rove))
+(in-package :dbi-cp-mysql-max-allowed-packet-test)
+
+(defvar *connection-pool* nil)
+
+(setup
+  (setf *connection-pool* (make-dbi-connection-pool :mysql
+                                                    :database-name "test"
+                                                    :username "root"
+                                                    :password "password"
+                                                    :host "mysql-test"
+                                                    :port 3306
+                                                    :initial-size 1
+                                                    :max-size 2)))
+
+(teardown
+  (shutdown *connection-pool*))
+
+
+(deftest test-max-allowed-packet-retrieval
+  (testing "max_allowed_packet should be retrieved from MySQL"
+    (let ((conn (get-connection *connection-pool*)))
+      (let ((max-packet (get-max-allowed-packet conn)))
+        (ok (integerp max-packet)
+            "max_allowed_packet should be an integer")
+        (ok (> max-packet 0)
+            "max_allowed_packet should be greater than 0")
+        ;; With docker-compose setting, it should be 1MB
+        (ok (= max-packet 1048576)
+            "max_allowed_packet should be 1MB (1048576 bytes) as configured"))
+      (disconnect conn))))
+
+
+(deftest test-check-packet-size-small-query
+  (testing "Small query should pass packet size check"
+    (let ((conn (get-connection *connection-pool*)))
+      (let ((small-sql "SELECT 1")
+            (params nil))
+        (ok (check-packet-size conn small-sql params)
+            "Small query should be within limit"))
+      (disconnect conn))))
+
+
+(deftest test-check-packet-size-medium-query
+  (testing "Medium query should pass packet size check"
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((medium-string (make-string 1000 :initial-element #\a))
+             (sql "SELECT ?")
+             (params (list medium-string)))
+        (ok (check-packet-size conn sql params)
+            "Medium query should be within limit"))
+      (disconnect conn))))
+
+
+(deftest test-packet-size-exceeded-small-query
+  (testing "Small query should not exceed packet size"
+    (let ((conn (get-connection *connection-pool*)))
+      (let ((small-sql "SELECT 1")
+            (params nil))
+        (ok (not (packet-size-exceeded-p conn small-sql params))
+            "Small query should not exceed limit"))
+      (disconnect conn))))
+
+
+(deftest test-large-query-warning
+  (testing "Large query approaching limit should trigger warning"
+    (let ((conn (get-connection *connection-pool*)))
+      (let* ((max-packet (get-max-allowed-packet conn)))
+        
+        ;; Create a string that exceeds 90% threshold
+        ;; If max_allowed_packet is 1MB, create 950KB string
+        (let* ((test-size (floor (* max-packet 0.95)))
+               (large-string (make-string test-size :initial-element #\a))
+               (warned nil))
+          
+          ;; Capture warning
+          (handler-bind
+              ((warning (lambda (w)
+                          (format t "~%WARNING CAPTURED: ~A~%" w)
+                          (setf warned t)
+                          (muffle-warning w))))
+            ;; Try to execute with large data
+            ;; This should trigger a warning
+            (handler-case
+                (let ((query (prepare conn "SELECT ?")))
+                  (execute query (list large-string)))
+              (error (e)
+                ;; May fail if packet is too large, that's ok
+                (format t "~%Error (expected): ~A~%" e))))
+          
+          (ok warned
+              "Warning should be triggered for large query")))
+      (disconnect conn))))
+
+
+(deftest test-actual-insert-with-large-data
+  (testing "Insert with large data should work"
+    (let ((conn (get-connection *connection-pool*)))
+      ;; Create table for testing
+      (do-sql conn "DROP TABLE IF EXISTS large_data_test")
+      (do-sql conn "CREATE TABLE large_data_test (id INTEGER PRIMARY KEY, data TEXT)")
+      
+      ;; Use a fixed 10KB size for testing
+      (let ((test-string (make-string 10240 :initial-element #\b)))
+        
+        ;; This should work without exceeding limit
+        (ok (not (packet-size-exceeded-p conn "INSERT INTO large_data_test (id, data) VALUES (?, ?)"
+                                         (list 1 test-string)))
+            "10KB query should not exceed limit")
+        
+        ;; Actually insert the data
+        (handler-case
+            (progn
+              (do-sql conn "INSERT INTO large_data_test (id, data) VALUES (?, ?)"
+                      (list 1 test-string))
+              
+              ;; Verify it was inserted
+              (let* ((query (prepare conn "SELECT LENGTH(data) as len FROM large_data_test WHERE id = 1"))
+                     (result (execute query))
+                     (row (fetch result)))
+                (ok (= (getf row :|len|) 10240)
+                    "Data length should be 10240")))
+          (error (e)
+            (format t "Error during insert: ~A~%" e)
+            (fail "Should not raise error during insert"))))
+      
+      ;; Cleanup
+      (do-sql conn "DROP TABLE large_data_test")
+      (disconnect conn))))
+
+
+(deftest test-max-allowed-packet-consistency
+  (testing "max_allowed_packet should be the same for all connections"
+    (let ((conn1 (get-connection *connection-pool*)))
+      (let ((max-packet-1 (get-max-allowed-packet conn1)))
+        (disconnect conn1)
+        ;; Get another connection after returning the first one
+        (let ((conn2 (get-connection *connection-pool*)))
+          (let ((max-packet-2 (get-max-allowed-packet conn2)))
+            (ok (= max-packet-1 max-packet-2)
+                "max_allowed_packet should be the same for all connections from the same pool"))
+          (disconnect conn2))))))
+
+
+(deftest test-non-mysql-connection
+  (testing "Non-MySQL connection should return NIL for max_allowed_packet"
+    ;; Create a SQLite pool for comparison
+    (let ((sqlite-pool (make-dbi-connection-pool :sqlite3
+                                                  :database-name ":memory:")))
+      (let ((conn (get-connection sqlite-pool)))
+        (ok (null (get-max-allowed-packet conn))
+            "SQLite connection should return NIL for max_allowed_packet")
+        (disconnect conn))
+      (shutdown sqlite-pool))))
+


### PR DESCRIPTION
### Description

This PR implements Phase 1 (Information Retrieval and API Provision) and Phase 2 (Warning Functionality) to support MySQL's `max_allowed_packet` limitation.

close: #13

#### Motivation

MySQL's `max_allowed_packet` setting limits the maximum packet size that can be sent/received between client and server (default 4MB). Attempting to send data exceeding this limit results in connection termination or errors. This implementation enables developers to be aware of this limitation and prevent unexpected errors.

#### Changes

**Phase 1: Information Retrieval and API Provision**
- Automatically retrieve `max_allowed_packet` when connecting to MySQL
- Provide three public APIs:
  - `get-max-allowed-packet`: Get the configuration value
  - `check-packet-size`: Check query size
  - `packet-size-exceeded-p`: Determine if limit is exceeded

**Phase 2: Warning Functionality**
- Automatically check query size during execution
- Issue warnings when exceeding 90% threshold (include query in warning)
- Include query text in error messages for better debugging
- Accurate byte count calculation with UTF-8 encoding

**Test Environment Improvements**
- Add healthcheck to Docker Compose
- Ensure DB is ready before running tests
- Configure MySQL max_allowed_packet to 1MB for testing

#### Technical Decisions

**MySQL Detection Method**
- Use `driver-name` keyword (`:mysql`) for detection
- Avoid type checking with `typep` to eliminate dependency on `dbd.mysql` package

**Data Storage Location**
- Store `max_allowed_packet` at pool level only once
- Reasonable and memory-efficient since it's a server configuration, not per-connection

#### Test Results

```
All 8 tests passed.
```

Warning functionality demonstration:
```
WARNING CAPTURED: Query size (996155 bytes) is approaching max_allowed_packet (1048576 bytes)
Query: SELECT ?
```

#### Breaking Changes

None. No impact on existing APIs.

#### Usage Example

```common-lisp
;; Create pool (automatically retrieves max_allowed_packet)
(defvar *pool*
  (dbi-cp:make-dbi-connection-pool :mysql
                                   :database-name "test"
                                   :username "root"
                                   :password "password"))

;; Check configuration value
(defvar *conn* (dbi-cp:get-connection *pool*))
(format t "Max packet: ~A bytes~%"
        (dbi-cp:get-max-allowed-packet *conn*))
;; => Max packet: 4194304 bytes

;; Check query size
(let ((large-data (make-string 1000000 :initial-element #\a)))
  (if (dbi-cp:check-packet-size *conn* "INSERT INTO t VALUES (?)"
                                (list large-data))
      (format t "OK~%")
      (format t "Too large!~%")))
```

#### Checklist

- [x] Phase 1 implementation completed
- [x] Phase 2 implementation completed
- [x] Added test code (8 tests)
- [x] All tests passed
- [x] Created documentation (docs/mysql-allowed-packet.md)
- [x] Improved Docker environment (healthcheck)
- [x] Maintained backward compatibility
- [x] No impact on non-MySQL environments

