### PR TITLE
Implemented `checkout-timeout` feature that allows waiting and retrying for a specified duration when acquiring connections from the connection pool.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fukamachi/sbcl
+FROM fukamachi/sbcl:2.5.10
 
 RUN apt-get update && apt-get install -y \
   default-libmysqlclient-dev \

--- a/src/dbi-cp.lisp
+++ b/src/dbi-cp.lisp
@@ -5,7 +5,8 @@
   (:import-from :dbi-cp.connectionpool
                 :make-dbi-connection-pool
                 :shutdown
-                :get-connection)
+                :get-connection
+                :checkout-timeout)
   (:import-from :dbi-cp.proxy
                 :disconnect
                 :prepare
@@ -58,6 +59,7 @@
            :with-transaction
            :disconnect
            :shutdown
+           :checkout-timeout
            :get-max-allowed-packet
            :check-packet-size
            :packet-size-exceeded-p


### PR DESCRIPTION
Fixes: #16

### Feature Addition

- Added `checkout-timeout` slot to `<dbi-connection-pool>` class (default: 30 seconds)
- Added `:checkout-timeout` parameter to `make-dbi-connection-pool` function
- Implemented timeout-based retry logic in `get-connection` method
  - Polls and retries at 0.1-second intervals when connection cannot be acquired
  - Raises `<dbi-cp-no-connection>` error when timeout is exceeded
- Exported `checkout-timeout` accessor from `dbi-cp` package


### Bug Fix

- Dockerfile: Fixed Roswell installation issue (pinned SBCL to 2.5.10)


### Reference Implementations

- Rails (ActiveRecord): checkout_timeout (default: 5 seconds)
- Spring Boot (HikariCP): connection-timeout (default: 30 seconds)
