### PR TITLE
Implement max-lifetime feature to automatically recreate connections exceeding specified age

### DIFF
--- a/dbi-cp-test.asd
+++ b/dbi-cp-test.asd
@@ -21,6 +21,7 @@
                   ((:file "sqlite3")
                    (:file "mysql")
                    (:file "mysql-max-allowed-packet")
+                   (:file "mysql-max-lifetime")
                    (:file "postgres")))
                  (:module "transaction"
                   :components

--- a/t/proxy/mysql-max-lifetime.lisp
+++ b/t/proxy/mysql-max-lifetime.lisp
@@ -1,0 +1,138 @@
+(in-package :cl-user)
+(defpackage dbi-cp-mysql-max-lifetime-test
+  (:use :cl
+        :dbi-cp
+        :rove))
+(in-package :dbi-cp-mysql-max-lifetime-test)
+
+(deftest mysql-retrieves-wait-timeout
+  (testing "MySQL connection pool retrieves wait_timeout from server"
+    (let ((pool (make-dbi-connection-pool :mysql
+                                          :database-name "test"
+                                          :username "root"
+                                          :password "password"
+                                          :host "mysql-test"
+                                          :port 3306
+                                          :initial-size 1
+                                          :max-size 2
+                                          :max-lifetime 1800)))
+      (unwind-protect
+           (progn
+             ;; Get wait_timeout from server directly
+             (let* ((conn (get-connection pool))
+                    (query (prepare conn "SHOW VARIABLES LIKE 'wait_timeout'"))
+                    (result (execute query))
+                    (row (fetch result))
+                    (wait-timeout (parse-integer (getf row :|Value|))))
+               (ok (> wait-timeout 0) "wait_timeout should be retrieved")
+
+               ;; If max-lifetime was adjusted, it should be less than wait_timeout
+               (let ((actual-max-lifetime (slot-value pool 'dbi-cp.connectionpool::max-lifetime)))
+                 (ok (< actual-max-lifetime wait-timeout)
+                     "max-lifetime should be less than wait_timeout"))
+
+               (disconnect conn)))
+        (shutdown pool)))))
+
+(deftest mysql-warns-when-max-lifetime-exceeds-wait-timeout
+  (testing "Warns when max-lifetime exceeds MySQL wait_timeout"
+    (let* ((warnings nil)
+           (*error-output* (make-string-output-stream)))
+      ;; Set a very large max-lifetime that will exceed wait_timeout
+      (let ((pool (make-dbi-connection-pool :mysql
+                                            :database-name "test"
+                                            :username "root"
+                                            :password "password"
+                                            :host "mysql-test"
+                                            :port 3306
+                                            :initial-size 1
+                                            :max-size 2
+                                            :max-lifetime 99999)))
+        (unwind-protect
+             (progn
+               (let ((warning-output (get-output-stream-string *error-output*)))
+                 ;; A warning should have been issued
+                 (ok (or (search "max-lifetime" warning-output)
+                         (search "wait_timeout" warning-output)
+                         ;; The max-lifetime should have been adjusted
+                         (< (slot-value pool 'dbi-cp.connectionpool::max-lifetime) 99999))
+                     "Should warn or adjust max-lifetime when it exceeds wait_timeout")))
+          (shutdown pool))))))
+
+(deftest mysql-max-lifetime-recreates-connections
+  (testing "MySQL connections are recreated after max-lifetime"
+    (let ((pool (make-dbi-connection-pool :mysql
+                                          :database-name "test"
+                                          :username "root"
+                                          :password "password"
+                                          :host "mysql-test"
+                                          :port 3306
+                                          :initial-size 1
+                                          :max-size 2
+                                          :max-lifetime 3
+                                          :idle-timeout 0
+                                          :reaper-interval 20)))
+      (unwind-protect
+           (progn
+             ;; Get connection and its created time
+             (let* ((conn (get-connection pool))
+                    (pooled-conn (find-if (lambda (pc)
+                                           (eq (slot-value pc 'dbi-cp.connectionpool::dbi-connection-proxy)
+                                               conn))
+                                         (coerce (slot-value pool 'dbi-cp.connectionpool::pool) 'list)))
+                    (created-time (slot-value pooled-conn 'dbi-cp.connectionpool::created-time)))
+
+               (ok created-time "Connection should have created-time")
+
+               ;; Use the connection
+               (do-sql conn "SELECT 1")
+
+               ;; Return connection
+               (disconnect conn)
+
+               ;; Wait for max-lifetime to expire
+               (sleep 4)
+
+               ;; Get connection again - it should be recreated
+               (let ((new-conn (get-connection pool)))
+                 (let* ((new-pooled-conn (find-if (lambda (pc)
+                                                   (eq (slot-value pc 'dbi-cp.connectionpool::dbi-connection-proxy)
+                                                       new-conn))
+                                                 (coerce (slot-value pool 'dbi-cp.connectionpool::pool) 'list)))
+                        (new-created-time (slot-value new-pooled-conn 'dbi-cp.connectionpool::created-time)))
+                   (ok (> new-created-time created-time)
+                       "Connection should be recreated with newer created-time")
+
+                   ;; New connection should work
+                   (ok (do-sql new-conn "SELECT 1") "Recreated connection should work")
+
+                   (disconnect new-conn)))))
+        (shutdown pool)))))
+
+(deftest mysql-max-lifetime-with-default-wait-timeout
+  (testing "max-lifetime works with MySQL default wait_timeout"
+    (let ((pool (make-dbi-connection-pool :mysql
+                                          :database-name "test"
+                                          :username "root"
+                                          :password "password"
+                                          :host "mysql-test"
+                                          :port 3306
+                                          :initial-size 1
+                                          :max-size 2
+                                          :max-lifetime 1800)))
+      (unwind-protect
+           (progn
+             ;; Check that max-lifetime was set appropriately
+             (let* ((actual-max-lifetime (slot-value pool 'dbi-cp.connectionpool::max-lifetime))
+                    (conn (get-connection pool))
+                    (query (prepare conn "SHOW VARIABLES LIKE 'wait_timeout'"))
+                    (result (execute query))
+                    (row (fetch result))
+                    (wait-timeout (parse-integer (getf row :|Value|))))
+
+               (ok (<= actual-max-lifetime (- wait-timeout 60))
+                   (format nil "max-lifetime (~A) should be at most wait_timeout - 60 (~A)"
+                          actual-max-lifetime (- wait-timeout 60)))
+
+               (disconnect conn)))
+        (shutdown pool)))))


### PR DESCRIPTION
## Summary

Implements the `max-lifetime` feature to automatically manage connection age and recreate connections that exceed a specified lifetime, addressing Issue #18.

close: #18 

## Changes

### Core Implementation
- Added `max-lifetime` parameter to `<dbi-connection-pool>` class (default: 1800 seconds / 30 minutes)
- Added `created-time` tracking to `<pooled-connection>` class
- Implemented connection age checking in `get-connection` method
- Enhanced reaper thread to check and recreate connections exceeding max-lifetime
- Added `%recreate-connection!` function to replace old connections

### MySQL-Specific Features
- Automatically retrieves `wait_timeout` from MySQL server
- Adjusts `max-lifetime` if it exceeds server's `wait_timeout`
- Emits warnings when `max-lifetime` is close to or exceeds `wait_timeout`
- Recommends using `wait_timeout - 60 seconds` as per HikariCP best practices


## Why 30 Minutes Default?

The default `max-lifetime` of **1800 seconds (30 minutes)** is chosen based on industry standards and best practices:

1. **Aligns with HikariCP**: The most widely-used connection pool in Java uses 30 minutes as the default
2. **PostgreSQL-friendly**: PostgreSQL has no default connection timeout, so 30 minutes provides reasonable protection against:
   - Firewall/load balancer timeouts (typically 1-2 hours)
   - Connection degradation and memory leaks
   - Stale configuration issues
3. **MySQL-safe**: Well below MySQL's default `wait_timeout` of 8 hours (28800 seconds)
4. **Balances stability vs overhead**: Frequent enough to prevent issues, infrequent enough to minimize reconnection overhead
5. **Widely adopted**: Used by pgbouncer (1 hour), go-pg, and other major connection pools

For MySQL specifically, the implementation automatically adjusts this value if it exceeds the server's `wait_timeout`.

